### PR TITLE
refactor: remove goerli

### DIFF
--- a/ape_tenderly/__init__.py
+++ b/ape_tenderly/__init__.py
@@ -6,8 +6,6 @@ NETWORKS = {
     "ethereum": [
         ("mainnet", TenderlyGatewayProvider),
         ("mainnet-fork", TenderlyForkProvider),
-        ("goerli", TenderlyGatewayProvider),
-        ("goerli-fork", TenderlyForkProvider),
         ("sepolia", TenderlyGatewayProvider),
         ("sepolia-fork", TenderlyForkProvider),
     ],
@@ -19,19 +17,19 @@ NETWORKS = {
     ],
     "arbitrum": [
         ("mainnet-fork", TenderlyForkProvider),
-        ("goerli-fork", TenderlyForkProvider),
+        ("sepolia-fork", TenderlyForkProvider),
     ],
     "optimism": [
         ("mainnet", TenderlyGatewayProvider),
         ("mainnet-fork", TenderlyForkProvider),
-        ("goerli", TenderlyGatewayProvider),
-        ("goerli-fork", TenderlyForkProvider),
+        ("sepolia", TenderlyGatewayProvider),
+        ("sepolia-fork", TenderlyForkProvider),
     ],
     "base": [
         ("mainnet", TenderlyGatewayProvider),
         ("mainnet-fork", TenderlyForkProvider),
-        ("goerli", TenderlyGatewayProvider),
-        ("goerli-fork", TenderlyForkProvider),
+        ("sepolia", TenderlyGatewayProvider),
+        ("sepolia-fork", TenderlyForkProvider),
     ],
     "avalance": [
         ("mainnet-fork", TenderlyForkProvider),

--- a/ape_tenderly/client.py
+++ b/ape_tenderly/client.py
@@ -81,7 +81,7 @@ class TenderlyClient:
 
     def get_gateway_rpc_uri(self, ecosystem_name: str, network_name: str) -> str:
         if ecosystem_name == "ethereum":
-            # e.g. Sepolia, Goerli, etc.
+            # e.g. Sepolia, etc.
             network_subdomain = network_name
         elif network_name == "mainnet":
             # e.g. Polygon mainnet, Optimism, etc.

--- a/ape_tenderly/provider.py
+++ b/ape_tenderly/provider.py
@@ -91,11 +91,10 @@ class TenderlyGatewayProvider(Web3Provider, UpstreamProvider):
             raise ProviderError(f"Failed to connect to Tenderly Gateway.\n{repr(err)}") from err
 
         # Any chain that *began* as PoA needs the middleware for pre-merge blocks
-        ethereum_sepolia = 11155111
         optimism = (10, 420)
         polygon = (137, 80001)
 
-        if chain_id in (ethereum_sepolia, *optimism, *polygon):
+        if chain_id in (*optimism, *polygon):
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)

--- a/ape_tenderly/provider.py
+++ b/ape_tenderly/provider.py
@@ -91,11 +91,11 @@ class TenderlyGatewayProvider(Web3Provider, UpstreamProvider):
             raise ProviderError(f"Failed to connect to Tenderly Gateway.\n{repr(err)}") from err
 
         # Any chain that *began* as PoA needs the middleware for pre-merge blocks
-        ethereum_goerli = 5
+        ethereum_sepolia = 11155111
         optimism = (10, 420)
         polygon = (137, 80001)
 
-        if chain_id in (ethereum_goerli, *optimism, *polygon):
+        if chain_id in (ethereum_sepolia, *optimism, *polygon):
             self._web3.middleware_onion.inject(geth_poa_middleware, layer=0)
 
         self._web3.eth.set_gas_price_strategy(rpc_gas_price_strategy)


### PR DESCRIPTION
### What I did

https://blog.ethereum.org/2023/11/30/goerli-lts-update
https://www.alchemy.com/blog/goerli-faucet-deprecation

Goerli support on all networks is ending soon:
- February 16th - [Base Goerli](https://www.alchemy.com/blog/base-goerli-testnet-deprecation)
- March 7th - [Optimism Goerli](https://www.alchemy.com/blog/optimism-goerli-testnet-deprecation)
- March 18th - [Arbitrum Goerli](https://www.alchemy.com/blog/arbitrum-goerli-testnet-deprecation)
- April 1st - [Ethereum Goerli](https://www.alchemy.com/blog/ethereum-goerli-testnet-deprecation)
- April 6th - [Polygon zkEVM Goerli](https://www.alchemy.com/blog/polygon-zkevm-cardona-is-live)
- April 11th - [Starknet Goerli](https://www.alchemy.com/blog/starknet-sepolia-is-live)
- April 13th - [Polygon Mumbai](https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
